### PR TITLE
Adding setup the environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ cd example-storefront
 ### Build and run in development mode with logs
 
 ```sh
+./bin/setup
 docker-compose up -d && docker-compose logs -f
 ```
 


### PR DESCRIPTION
Adding the missing `./bin/setup` setup the environment variables

Resolves No Issues
Impact: **minor**
Type: **docs**

## Issue

Just adding missing step in the docs

## Solution

## Breaking changes
None

## Testing
None

More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/trunk/contributing-to-reaction)
